### PR TITLE
Add server tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Test coverage
+coverage/

--- a/mcp-api/src/auth/auth.controller.spec.ts
+++ b/mcp-api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,28 @@
+import { Test } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+jest.mock('bcrypt', () => ({
+  hashSync: () => 'hash',
+  compareSync: (p: string, h: string) => p === 'demo',
+}));
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let auth: jest.Mocked<AuthService>;
+
+  beforeEach(async () => {
+    auth = { login: jest.fn() } as any;
+    const module = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: auth }],
+    }).compile();
+    controller = module.get(AuthController);
+  });
+
+  it('delegates login', async () => {
+    auth.login.mockResolvedValue({ t: 1 } as any);
+    await controller.login({ username: 'demo', password: 'demo' });
+    expect(auth.login).toHaveBeenCalled();
+  });
+});

--- a/mcp-api/src/auth/auth.service.spec.ts
+++ b/mcp-api/src/auth/auth.service.spec.ts
@@ -1,0 +1,29 @@
+import { Test } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+
+jest.mock('bcrypt', () => ({
+  hashSync: () => 'hash',
+  compareSync: (p: string, h: string) => p === 'demo',
+}));
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let jwt: jest.Mocked<JwtService>;
+
+  beforeEach(async () => {
+    jwt = { signAsync: jest.fn().mockResolvedValue('token') } as any;
+    const module = await Test.createTestingModule({
+      providers: [AuthService, { provide: JwtService, useValue: jwt }],
+    }).compile();
+    service = module.get(AuthService);
+  });
+
+  it('returns token on valid credentials', async () => {
+    await expect(service.login({ username: 'demo', password: 'demo' })).resolves.toEqual({ access_token: 'token' });
+  });
+
+  it('throws on invalid credentials', async () => {
+    await expect(service.login({ username: 'bad', password: 'demo' })).rejects.toThrow();
+  });
+});

--- a/mcp-api/src/auth/jwt.strategy.spec.ts
+++ b/mcp-api/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,8 @@
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtStrategy', () => {
+  it('maps payload to user object', () => {
+    const strat = new JwtStrategy();
+    expect(strat.validate({ sub: 'u1' })).toEqual({ userId: 'u1' });
+  });
+});

--- a/mcp-api/src/authors/authors.controller.spec.ts
+++ b/mcp-api/src/authors/authors.controller.spec.ts
@@ -1,0 +1,27 @@
+import { Test } from '@nestjs/testing';
+import { AuthorsController } from './authors.controller';
+import { AuthorsService } from './authors.service';
+
+describe('AuthorsController', () => {
+  let controller: AuthorsController;
+  let authors: jest.Mocked<AuthorsService>;
+
+  beforeEach(async () => {
+    authors = { paginate: jest.fn(), findOne: jest.fn() } as any;
+    const module = await Test.createTestingModule({
+      controllers: [AuthorsController],
+      providers: [{ provide: AuthorsService, useValue: authors }],
+    }).compile();
+    controller = module.get(AuthorsController);
+  });
+
+  it('lists authors', () => {
+    controller.list({ page: 1, size: 2 });
+    expect(authors.paginate).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('gets detail', () => {
+    controller.detail('a1');
+    expect(authors.findOne).toHaveBeenCalledWith('a1');
+  });
+});

--- a/mcp-api/src/authors/authors.service.spec.ts
+++ b/mcp-api/src/authors/authors.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Author } from '../database/entities/author.entity';
+import { AuthorsService } from './authors.service';
+
+describe('AuthorsService', () => {
+  let service: AuthorsService;
+  let repo: jest.Mocked<Repository<Author>>;
+
+  beforeEach(async () => {
+    repo = {
+      findAndCount: jest.fn(),
+      findOne: jest.fn(),
+    } as any;
+
+    const module = await Test.createTestingModule({
+      providers: [AuthorsService, { provide: getRepositoryToken(Author), useValue: repo }],
+    }).compile();
+    service = module.get(AuthorsService);
+  });
+
+  it('paginates authors', async () => {
+    repo.findAndCount.mockResolvedValueOnce([[{ id: 'a1' } as Author], 1]);
+    await expect(service.paginate(1, 5)).resolves.toEqual({
+      page: 1,
+      size: 5,
+      total: 1,
+      data: [{ id: 'a1' }],
+    });
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      skip: 0,
+      take: 5,
+      order: { name: 'ASC' },
+    });
+  });
+
+  it('finds one author', async () => {
+    repo.findOne.mockResolvedValueOnce({ id: 'a1' } as Author);
+    await expect(service.findOne('a1')).resolves.toEqual({ id: 'a1' });
+  });
+
+  it('throws when author missing', async () => {
+    repo.findOne.mockResolvedValueOnce(null as any);
+    await expect(service.findOne('a1')).rejects.toThrow('Author a1 not found');
+  });
+});

--- a/mcp-api/src/books/books.controller.spec.ts
+++ b/mcp-api/src/books/books.controller.spec.ts
@@ -1,0 +1,27 @@
+import { Test } from '@nestjs/testing';
+import { BooksController } from './books.controller';
+import { BooksService } from './books.service';
+
+describe('BooksController', () => {
+  let controller: BooksController;
+  let books: jest.Mocked<BooksService>;
+
+  beforeEach(async () => {
+    books = { paginate: jest.fn(), findOne: jest.fn() } as any;
+    const module = await Test.createTestingModule({
+      controllers: [BooksController],
+      providers: [{ provide: BooksService, useValue: books }],
+    }).compile();
+    controller = module.get(BooksController);
+  });
+
+  it('lists books', () => {
+    controller.list({ page: 1, size: 2 });
+    expect(books.paginate).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('gets detail', () => {
+    controller.detail('b1');
+    expect(books.findOne).toHaveBeenCalledWith('b1');
+  });
+});

--- a/mcp-api/src/books/books.service.spec.ts
+++ b/mcp-api/src/books/books.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Book } from '../database/entities/book.entity';
+import { BooksService } from './books.service';
+
+describe('BooksService', () => {
+  let service: BooksService;
+  let repo: jest.Mocked<Repository<Book>>;
+
+  beforeEach(async () => {
+    repo = {
+      findAndCount: jest.fn(),
+      findOne: jest.fn(),
+    } as any;
+
+    const module = await Test.createTestingModule({
+      providers: [BooksService, { provide: getRepositoryToken(Book), useValue: repo }],
+    }).compile();
+    service = module.get(BooksService);
+  });
+
+  it('paginates books', async () => {
+    repo.findAndCount.mockResolvedValueOnce([[{ id: 'b1' } as Book], 1]);
+    await expect(service.paginate(1, 10)).resolves.toEqual({
+      page: 1,
+      size: 10,
+      total: 1,
+      data: [{ id: 'b1' }],
+    });
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      skip: 0,
+      take: 10,
+      order: { title: 'ASC' },
+    });
+  });
+
+  it('finds one book', async () => {
+    repo.findOne.mockResolvedValueOnce({ id: 'b1' } as Book);
+    await expect(service.findOne('b1')).resolves.toEqual({ id: 'b1' });
+  });
+
+  it('throws when book missing', async () => {
+    repo.findOne.mockResolvedValueOnce(null as any);
+    await expect(service.findOne('b1')).rejects.toThrow('Book b1 not found');
+  });
+});

--- a/mcp-api/src/cart/cart.controller.spec.ts
+++ b/mcp-api/src/cart/cart.controller.spec.ts
@@ -1,0 +1,39 @@
+import { Test } from '@nestjs/testing';
+import { CartController } from './cart.controller';
+import { CartService } from './cart.service';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+describe('CartController', () => {
+  let controller: CartController;
+  let cart: jest.Mocked<CartService>;
+
+  beforeEach(async () => {
+    cart = { get: jest.fn(), add: jest.fn(), remove: jest.fn() } as any;
+    const module = await Test.createTestingModule({
+      controllers: [CartController],
+      providers: [{ provide: CartService, useValue: cart }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = module.get(CartController);
+  });
+
+  const req = { user: { userId: 'u1' } } as any;
+
+  it('views cart', () => {
+    cart.get.mockReturnValue({ items: [] });
+    expect(controller.view(req)).toEqual({ items: [] });
+    expect(cart.get).toHaveBeenCalledWith('u1');
+  });
+
+  it('adds item', () => {
+    controller.add(req, 'b1', 2);
+    expect(cart.add).toHaveBeenCalledWith('u1', 'b1', 2);
+  });
+
+  it('removes item', () => {
+    controller.remove(req, 'b1');
+    expect(cart.remove).toHaveBeenCalledWith('u1', 'b1');
+  });
+});

--- a/mcp-api/src/cart/cart.service.spec.ts
+++ b/mcp-api/src/cart/cart.service.spec.ts
@@ -1,0 +1,36 @@
+import { CartService } from './cart.service';
+
+describe('CartService', () => {
+  let service: CartService;
+
+  beforeEach(() => {
+    service = new CartService();
+  });
+
+  it('initially returns empty cart', () => {
+    expect(service.get('user1')).toEqual({ items: [] });
+  });
+
+  it('adds items and increments quantity', () => {
+    service.add('u1', 'b1');
+    service.add('u1', 'b1');
+    service.add('u1', 'b2', 3);
+    expect(service.get('u1')).toEqual({ items: [
+      { bookId: 'b1', quantity: 2 },
+      { bookId: 'b2', quantity: 3 },
+    ] });
+  });
+
+  it('removes items', () => {
+    service.add('u1', 'b1');
+    service.add('u1', 'b2');
+    service.remove('u1', 'b1');
+    expect(service.get('u1')).toEqual({ items: [{ bookId: 'b2', quantity: 1 }] });
+  });
+
+  it('clears cart', () => {
+    service.add('u1', 'b1');
+    service.clear('u1');
+    expect(service.get('u1')).toEqual({ items: [] });
+  });
+});

--- a/mcp-api/src/database/seed.service.spec.ts
+++ b/mcp-api/src/database/seed.service.spec.ts
@@ -1,0 +1,31 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SeedService } from './seed.service';
+import { Author } from './entities/author.entity';
+import { Book } from './entities/book.entity';
+
+describe('SeedService', () => {
+  let service: SeedService;
+  let authorRepo: jest.Mocked<Repository<Author>>;
+  let bookRepo: jest.Mocked<Repository<Book>>;
+
+  beforeEach(async () => {
+    authorRepo = { create: jest.fn((a) => a), save: jest.fn(async (a) => ({ id: 'a', ...a })) } as any;
+    bookRepo = { create: jest.fn((b) => b), save: jest.fn(async (b) => ({ id: 'b', ...b })) } as any;
+    const module = await Test.createTestingModule({
+      providers: [
+        SeedService,
+        { provide: getRepositoryToken(Author), useValue: authorRepo },
+        { provide: getRepositoryToken(Book), useValue: bookRepo },
+      ],
+    }).compile();
+    service = module.get(SeedService);
+  });
+
+  it('seeds authors and books', async () => {
+    await service.seed();
+    expect(authorRepo.save).toHaveBeenCalled();
+    expect(bookRepo.save).toHaveBeenCalled();
+  });
+});

--- a/mcp-api/src/main.spec.ts
+++ b/mcp-api/src/main.spec.ts
@@ -1,0 +1,19 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+
+jest.mock('@nestjs/core', () => ({ NestFactory: { create: jest.fn() } }));
+jest.mock('./app.module', () => ({ AppModule: class {} }));
+
+describe('bootstrap', () => {
+  it('creates app and listens', async () => {
+    const useGlobalPipes = jest.fn();
+    const listen = jest.fn();
+    (NestFactory.create as jest.Mock).mockResolvedValue({ useGlobalPipes, listen });
+
+    await import('./main');
+    expect(NestFactory.create).toHaveBeenCalledWith(AppModule);
+    expect(useGlobalPipes).toHaveBeenCalled();
+    expect(listen).toHaveBeenCalledWith(3000);
+  });
+});

--- a/mcp-api/src/mcp/mcp.controller.spec.ts
+++ b/mcp-api/src/mcp/mcp.controller.spec.ts
@@ -1,0 +1,98 @@
+import { Test } from '@nestjs/testing';
+import { McpController } from './mcp.controller';
+import { BooksService } from '../books/books.service';
+import { AuthorsService } from '../authors/authors.service';
+import { CartService } from '../cart/cart.service';
+import { OrdersService } from '../orders/orders.service';
+
+const createMock = <T extends object>() => ({}) as jest.Mocked<T>;
+
+describe('McpController', () => {
+  let controller: McpController;
+  let books: jest.Mocked<BooksService>;
+  let authors: jest.Mocked<AuthorsService>;
+  let cart: jest.Mocked<CartService>;
+  let orders: jest.Mocked<OrdersService>;
+
+  beforeEach(async () => {
+    books = { paginate: jest.fn(), findOne: jest.fn() } as any;
+    authors = { findOne: jest.fn() } as any;
+    cart = { add: jest.fn(), remove: jest.fn(), get: jest.fn(), clear: jest.fn() } as any;
+    orders = { place: jest.fn(), paginate: jest.fn(), findOne: jest.fn() } as any;
+
+    const module = await Test.createTestingModule({
+      controllers: [McpController],
+      providers: [
+        { provide: BooksService, useValue: books },
+        { provide: AuthorsService, useValue: authors },
+        { provide: CartService, useValue: cart },
+        { provide: OrdersService, useValue: orders },
+      ],
+    }).compile();
+    controller = module.get(McpController);
+  });
+
+  const req = { user: { userId: 'u1' } } as any;
+
+  it('handles listInventory', async () => {
+    books.paginate.mockResolvedValueOnce('data' as any);
+    const res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'listInventory', params: { page: 2, size: 5 } } as any, req);
+    expect(res.result).toBe('data');
+    expect(books.paginate).toHaveBeenCalledWith(2,5);
+  });
+
+  it('handles addToCart', async () => {
+    cart.add.mockReturnValueOnce({ items: [] } as any);
+    const res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'addToCart', params: { bookId: 'b1', qty: 2 } } as any, req);
+    expect(cart.add).toHaveBeenCalledWith('u1','b1',2);
+    expect(res.result).toEqual({ items: [] });
+  });
+
+  it('handles removeFromCart and viewCart', async () => {
+    cart.remove.mockReturnValueOnce({ items: [] } as any);
+    let res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'removeFromCart', params: { bookId: 'b1' } } as any, req);
+    expect(cart.remove).toHaveBeenCalledWith('u1','b1');
+    expect(res.result).toEqual({ items: [] });
+
+    cart.get.mockReturnValueOnce({ items: [] } as any);
+    res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'viewCart', params: {} } as any, req);
+    expect(cart.get).toHaveBeenCalledWith('u1');
+    expect(res.result).toEqual({ items: [] });
+  });
+
+  it('handles placeOrder and listing', async () => {
+    cart.get.mockReturnValueOnce({ items: [] } as any);
+    orders.place.mockResolvedValueOnce('o' as any);
+    let res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'placeOrder', params: {} } as any, req);
+    expect(orders.place).toHaveBeenCalled();
+    expect(cart.clear).toHaveBeenCalledWith('u1');
+    expect(res.result).toBe('o');
+
+    orders.paginate.mockResolvedValueOnce('list' as any);
+    res = await controller.rpc({ jsonrpc: '2.0', id: 2, method: 'listOrders', params: { page: 1, size: 3 } } as any, req);
+    expect(orders.paginate).toHaveBeenCalledWith('u1',1,3);
+    expect(res.result).toBe('list');
+  });
+
+  it('handles order and book/author details', async () => {
+    orders.findOne.mockResolvedValueOnce('order' as any);
+    let res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'orderDetails', params: { id: 'o1' } } as any, req);
+    expect(orders.findOne).toHaveBeenCalledWith('u1','o1');
+    expect(res.result).toBe('order');
+
+    books.findOne.mockResolvedValueOnce('book' as any);
+    res = await controller.rpc({ jsonrpc: '2.0', id: 2, method: 'bookDetails', params: { id: 'b1' } } as any, req);
+    expect(books.findOne).toHaveBeenCalledWith('b1');
+    expect(res.result).toBe('book');
+
+    authors.findOne.mockResolvedValueOnce('author' as any);
+    res = await controller.rpc({ jsonrpc: '2.0', id: 3, method: 'authorDetails', params: { id: 'a1' } } as any, req);
+    expect(authors.findOne).toHaveBeenCalledWith('a1');
+    expect(res.result).toBe('author');
+  });
+
+  it('returns error for unknown method', async () => {
+    const res = await controller.rpc({ jsonrpc: '2.0', id: 1, method: 'bogus', params: {} } as any, req);
+    expect((res as any).error.code).toBe(-32601);
+  });
+});

--- a/mcp-api/src/orders/orders.controller.spec.ts
+++ b/mcp-api/src/orders/orders.controller.spec.ts
@@ -1,0 +1,43 @@
+import { Test } from '@nestjs/testing';
+import { OrdersController } from './orders.controller';
+import { OrdersService } from './orders.service';
+import { CartService } from '../cart/cart.service';
+
+describe('OrdersController', () => {
+  let controller: OrdersController;
+  let orders: jest.Mocked<OrdersService>;
+  let cart: jest.Mocked<CartService>;
+
+  beforeEach(async () => {
+    orders = { place: jest.fn(), paginate: jest.fn(), findOne: jest.fn() } as any;
+    cart = { get: jest.fn(), clear: jest.fn() } as any;
+    const module = await Test.createTestingModule({
+      controllers: [OrdersController],
+      providers: [
+        { provide: OrdersService, useValue: orders },
+        { provide: CartService, useValue: cart },
+      ],
+    }).compile();
+    controller = module.get(OrdersController);
+  });
+
+  const req = { user: { userId: 'u1' } } as any;
+
+  it('places order', async () => {
+    cart.get.mockReturnValueOnce({} as any);
+    orders.place.mockResolvedValueOnce({ id: 'o1' } as any);
+    await controller.place(req);
+    expect(cart.clear).toHaveBeenCalledWith('u1');
+    expect(orders.place).toHaveBeenCalled();
+  });
+
+  it('lists orders', () => {
+    controller.list(req, { page: 1, size: 2 });
+    expect(orders.paginate).toHaveBeenCalledWith('u1', 1, 2);
+  });
+
+  it('gets order detail', () => {
+    controller.detail(req, 'o1');
+    expect(orders.findOne).toHaveBeenCalledWith('u1', 'o1');
+  });
+});

--- a/mcp-api/src/orders/orders.service.spec.ts
+++ b/mcp-api/src/orders/orders.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OrdersService } from './orders.service';
+import { Order } from '../database/entities/order.entity';
+import { OrderItem } from '../database/entities/order-item.entity';
+import { Book } from '../database/entities/book.entity';
+import { Cart } from '../cart/cart.service';
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+  let orderRepo: jest.Mocked<Repository<Order>>;
+  let itemRepo: jest.Mocked<Repository<OrderItem>>;
+  let bookRepo: jest.Mocked<Repository<Book>>;
+
+  beforeEach(async () => {
+    orderRepo = { create: jest.fn(), save: jest.fn(), findAndCount: jest.fn(), findOne: jest.fn() } as any;
+    itemRepo = { create: jest.fn() } as any;
+    bookRepo = { findByIds: jest.fn() } as any;
+
+    const module = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        { provide: getRepositoryToken(Order), useValue: orderRepo },
+        { provide: getRepositoryToken(OrderItem), useValue: itemRepo },
+        { provide: getRepositoryToken(Book), useValue: bookRepo },
+      ],
+    }).compile();
+
+    service = module.get(OrdersService);
+  });
+
+  it('places an order', async () => {
+    const cart: Cart = { items: [{ bookId: 'b1', quantity: 2 }] };
+    bookRepo.findByIds.mockResolvedValueOnce([{ id: 'b1', price: 10 } as Book]);
+    itemRepo.create.mockReturnValueOnce({} as OrderItem);
+    orderRepo.create.mockReturnValueOnce({ items: [{}] } as Order);
+    orderRepo.save.mockResolvedValueOnce({ id: 'o1' } as Order);
+
+    await expect(service.place('u1', cart)).resolves.toEqual({ id: 'o1' });
+    expect(bookRepo.findByIds).toHaveBeenCalled();
+    expect(orderRepo.save).toHaveBeenCalled();
+  });
+
+  it('paginates orders', async () => {
+    orderRepo.findAndCount.mockResolvedValueOnce([[{ id: 'o1' } as Order], 1]);
+    await expect(service.paginate('u1', 1, 5)).resolves.toEqual({
+      page: 1,
+      size: 5,
+      total: 1,
+      data: [{ id: 'o1' }],
+    });
+  });
+
+  it('finds one order', async () => {
+    orderRepo.findOne.mockResolvedValueOnce({ id: 'o1' } as Order);
+    await expect(service.findOne('u1', 'o1')).resolves.toEqual({ id: 'o1' });
+  });
+
+  it('throws when missing', async () => {
+    orderRepo.findOne.mockResolvedValueOnce(null as any);
+    await expect(service.findOne('u1', 'o1')).rejects.toThrow('Order o1 not found');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for core services and controllers in the mcp-api server
- mock external dependencies such as TypeORM repositories and Nest components
- ensure bootstrap can be imported in tests

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68658d5019ec83218e60a221434e5ead