### PR TITLE
Enhance MCP agent chat UX

### DIFF
--- a/mcp-agent/client/src/pages/Chat.tsx
+++ b/mcp-agent/client/src/pages/Chat.tsx
@@ -1,16 +1,31 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { marked } from 'marked';
 
 interface Entry { role: string; content: string }
 
 export default function Chat() {
   const [input, setInput] = useState('');
   const [log, setLog] = useState<Entry[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = () => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = Math.min(el.scrollHeight, 150) + 'px';
+    }
+  };
+
+  useEffect(() => {
+    adjustHeight();
+  }, [input]);
 
   const send = async () => {
     if (!input.trim()) return;
     const message = input.trim();
     setLog(l => [...l, { role: 'You', content: message }]);
     setInput('');
+    adjustHeight();
     const res = await fetch('/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -18,20 +33,34 @@ export default function Chat() {
     });
     const data = await res.json();
     setLog(l => [...l, { role: 'Assistant', content: data.reply }]);
+    textareaRef.current?.focus();
   };
 
   return (
     <div className="chat">
       <div className="log">
         {log.map((e, i) => (
-          <div key={i}><strong>{e.role}:</strong> {e.content}</div>
+          <div key={i} className={`entry ${e.role === 'You' ? 'user' : 'assistant'}`}>
+            <div
+              className="bubble"
+              dangerouslySetInnerHTML={{ __html: marked.parse(e.content) }}
+            />
+          </div>
         ))}
       </div>
       <div className="input-row">
-        <input
+        <textarea
+          ref={textareaRef}
           value={input}
           onChange={e => setInput(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') send(); }}
+          onInput={adjustHeight}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+          rows={1}
         />
         <button onClick={send}>Send</button>
       </div>

--- a/mcp-agent/client/src/style.css
+++ b/mcp-agent/client/src/style.css
@@ -1,21 +1,67 @@
 body {
-  font-family: Arial, sans-serif;
-  margin: 20px;
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  padding: 20px;
+  background: #f2f5f9;
 }
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
 .container header {
   margin-bottom: 1rem;
+  text-align: center;
 }
-.chat .log {
-  border: 1px solid #ccc;
+
+.chat {
+  background: #fff;
+  border-radius: 8px;
   padding: 10px;
-  height: 300px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.chat .log {
+  padding: 10px;
+  height: 60vh;
   overflow-y: auto;
   margin-bottom: 10px;
 }
+
+.chat .entry {
+  margin-bottom: 8px;
+}
+
+.chat .entry.user {
+  text-align: right;
+}
+
+.chat .entry .bubble {
+  display: inline-block;
+  padding: 8px 12px;
+  border-radius: 4px;
+  max-width: 70%;
+  line-height: 1.4;
+}
+
+.chat .entry.user .bubble {
+  background: #dcf8c6;
+}
+
+.chat .entry.assistant .bubble {
+  background: #e6e6eb;
+}
+
 .chat .input-row {
   display: flex;
   gap: 0.5rem;
 }
-.chat input {
+
+.chat textarea {
   flex: 1;
+  resize: none;
+  max-height: 150px;
+  padding: 8px;
+  border-radius: 4px;
 }

--- a/mcp-agent/package.json
+++ b/mcp-agent/package.json
@@ -15,7 +15,8 @@
     "openai": "^4.25.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.0"
+    "react-router-dom": "^6.21.0",
+    "marked": "^9.1.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/mcp-agent/public/index.html
+++ b/mcp-agent/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MCP Agent</title>
-    <script type="module" crossorigin src="/assets/index-1248d80e.js"></script>
-    <link rel="stylesheet" href="/assets/index-e112f0de.css">
+    <script type="module" crossorigin src="/assets/index-37105bcc.js"></script>
+    <link rel="stylesheet" href="/assets/index-55cd16a1.css">
   </head>
   <body>
     <div id="root"></div>

--- a/mcp-agent/yarn.lock
+++ b/mcp-agent/yarn.lock
@@ -1004,6 +1004,11 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+marked@^9.1.1:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-9.1.6.tgz#5d2a3f8180abfbc5d62e3258a38a1c19c0381695"
+  integrity sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"


### PR DESCRIPTION
## Summary
- modernize the chat layout with new colors
- render assistant messages using markdown
- support growing textarea input
- add `marked` as a dependency

## Testing
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6866a5ddc448832193514109e84a1669