### PR TITLE
Persist chat history and add simple RAG search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Test coverage
 coverage/
+mcp-agent/history.jsonl


### PR DESCRIPTION
## Summary
- store past chat messages in `mcp-agent/history.jsonl`
- ignore history file in git
- use a simple local retrieval method to include relevant past messages in the model context
- persist all user, assistant and tool messages for later sessions

## Testing
- `yarn build` *(fails: package installation requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6866a7fc8e4c8321ac76940fa69fda07